### PR TITLE
add readme to example to show how to use

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,29 @@
+# How to use ?
+## install the dependencies.
+```bash
+pip3 install -r requirements.txt
+```
+## txt2img
+txt2img is a model used for generating images from text. It employs the framework of generative adversarial networks (GANs) to generate corresponding images based on input text descriptions. This model can be used for various tasks, such as generating images of scenes or objects based on text, or transforming natural language descriptions into visual conceptual representations.
+
+```bash
+python3 sdcn_run.py txt2img params-txt2img.json OUTPUT_IMAGE.png
+# or
+python3 txt2img.py
+```
+
+## img2img
+img2img refers to a type of machine learning model that takes an input image and generates an output image with desired modifications or transformations. This approach is often used for tasks such as image-to-image translation, style transfer, and image colorization. The model learns to map the input image to the desired output image by training on large datasets of paired examples, where each example consists of an input image and its corresponding desired output image.
+
+```bash
+python3 sdcn_run.py img2img params-img2img.json ORIGINAL_IMAGE.png OUTPUT_IMAGE.png
+# or 
+python3 img2img.py ORIGINAL_IMAGE.png
+```
+
+
+
+
+
+
+

--- a/example/README.md
+++ b/example/README.md
@@ -20,10 +20,3 @@ python3 sdcn_run.py img2img params-img2img.json ORIGINAL_IMAGE.png OUTPUT_IMAGE.
 # or 
 python3 img2img.py ORIGINAL_IMAGE.png
 ```
-
-
-
-
-
-
-

--- a/example/img2img.py
+++ b/example/img2img.py
@@ -1,8 +1,10 @@
+import sys
 import requests
 import json
 import base64
 
-with open("./img2img.png", "rb") as f:
+init_img_filename = sys.argv[1]
+with open(init_img_filename, "rb") as f:
     init_img = base64.b64encode(f.read()).decode()
 
 params = {

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,0 +1,2 @@
+requests
+image


### PR DESCRIPTION
Adding a README to the example is essential. Because it can help everyone understand how to use the Python script inside the example folder.






